### PR TITLE
Fix 404 on /privacy by redirecting to /privacy-policy

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -28,6 +28,16 @@ const nextConfig = {
       },
     ],
   },
+
+  async redirects() {
+    return [
+      {
+        source: "/privacy",
+        destination: "/privacy-policy",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- Production link `https://levelup.supersheldon.com/privacy` was 404ing because the page lives at `/privacy-policy` while the footer (`src/components/Footer.tsx`) and external links point to `/privacy`.
- Added a permanent (308) redirect in `next.config.js` so both paths resolve correctly.

## Test plan
- [x] `curl -I http://localhost:3001/privacy` returns 308 with `Location: /privacy-policy`
- [ ] After deploy, hit `https://levelup.supersheldon.com/privacy` and confirm it redirects to `/privacy-policy`
- [ ] Footer "Privacy Policy" link from landing page works

Co-Authored-By: Claude Opus 4.7 (1M context)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added permanent redirect from `/privacy` to `/privacy-policy` URL path.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Tech-SuperSheldon/Quiz_App/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->